### PR TITLE
Prepare release of package to npm

### DIFF
--- a/CONTRIBUTING_PCT.md
+++ b/CONTRIBUTING_PCT.md
@@ -15,3 +15,4 @@
 ## PRs of PCT that were added in this fork
 
 Allow VEC3 uniforms to be transformed into model coordinates (#1)
+Prepare release of package to npm (#2)

--- a/Documentation/Contributors/ReleaseGuide/README.md
+++ b/Documentation/Contributors/ReleaseGuide/README.md
@@ -4,6 +4,19 @@ We release Cesium on the first work day of every month. The [Release Schedule](.
 
 There is no release manager; instead, our community shares the responsibility. Any committer can create the release for a given month, and at any point, they can pass the responsibility to someone else, or someone else can ask for it. This spreads knowledge, avoids stratification, avoids a single point of failure, and is beautifully unstructured ([more info](https://community.cesium.com/t/cesium-releases/45)).
 
+## Releasing PCT fork of Cesium
+
+1. Rebase to the latest tag of the original repo and push to `main` (ideally one day after the monthly release of Cesium).
+   1. Resolve any merge conflicts. This applies specifically to the `package.json`, which potentially has conflicts due to the changes we made for our package.
+   2. Push to `main`. This requires force-pushing as our commits should always be the latest commits in the history.
+2. Run `npm install` to install all dependencies and dev-dependencies required for building.
+3. Run `npm run build-release` to build all artifacts required for the package to release.
+4. Publish the top-level `cesium` package to npm by running `npm publish` in the repository root.
+
+---
+
+_Original instructions:_
+
 ## One week before release
 
 1. Check for any outdated dependencies with `npm outdated`.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
-  "name": "cesium",
+  "name": "@pointcloudtechnology/cesium",
   "version": "1.129.0",
   "description": "CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
-  "homepage": "http://cesium.com/cesiumjs/",
+  "homepage": "https://github.com/pointcloudtechnology/cesium#readme",
   "license": "Apache-2.0",
-  "author": {
-    "name": "Cesium GS, Inc.",
-    "url": "https://cesium.com"
-  },
+  "author": "Point Cloud Technology GmbH",
   "contributors": [
     {
       "name": "CesiumJS community",
-      "url": "https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTORS.md"
+      "url": "https://github.com/pointcloudtechnology/cesium/blob/main/CONTRIBUTORS.md"
     }
   ],
   "keywords": [
@@ -23,10 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/CesiumGS/cesium.git"
-  },
-  "bugs": {
-    "url": "https://github.com/CesiumGS/cesium/issues"
+    "url": "https://github.com/pointcloudtechnology/cesium.git"
   },
   "main": "index.cjs",
   "module": "./Source/Cesium.js",
@@ -158,5 +152,8 @@
   "workspaces": [
     "packages/engine",
     "packages/widgets"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
# Description

This PR adapts the `package.json` file for the release of our fork as npm package. Additionally, the required steps for building a release are documented in `ReleaseGuide/README.md`.

## Testing plan

You may follow the steps described in the release guide. Instead of publishing the package with `npm publish`, you can use `npm pack` to create a `.tgz` of the package locally as it would be published on npm. You may also compare the contents of the `.tgz` package with the [original Cesium package files](https://www.npmjs.com/package/cesium?activeTab=code) to ensure that no additional files are pushed nor that files are missing.